### PR TITLE
Massive Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Gatsby WordPress inline images (ALPHA)
+# Gatsby WordPress inline images
 
 `gatsby-source-wordpress` doesn't process images in blocks of text which means your admin site has to serve the images. This plugin solves that.
+
+Require `gatsby-source-wordpress` and `gatsby-image` to be preinstalled
 
 This is a WIP and little testing has been done. I modified this code from my alternative WP source plugin [`wordsby`](https://github.com/TylerBarnes/wordsby) which was originally modified from [`gatsby-remark-images`](https://www.gatsbyjs.org/packages/gatsby-remark-images/). Currently this plugin isn't doing any caching of images. This plugin is also currently hardcoded to only work on pages and posts and only on the post content field. Other post types and fields will be supported later.
 There is a bunch of commented out code that needs to be sorted through. If you need this plugin please help out by sending PR's!
@@ -45,7 +47,9 @@ Be sure to specify your baseurl and protocol a second time in the `gatsby-wordpr
 		// defaults
 		maxWidth: 650,
 		wrapperStyle: ``,
+		postTypes: ["post", "page"],
 		backgroundColor: `white`,
+		withWebp: false, // enable WebP files generation
 		// add any image sharp fluid options here
 		// ...
 	}

--- a/constants.js
+++ b/constants.js
@@ -1,3 +1,6 @@
-exports.imageClass = `gatsby-resp-image-image`;
-exports.imageWrapperClass = `gatsby-resp-image-wrapper`;
-exports.imageBackgroundClass = `gatsby-resp-image-background-image`;
+const imageWrapperSelector = `.gatsby-image-wrapper`;
+const imageSelector = `${imageWrapperSelector} picture img`;
+const imageBackgroundSelector = `${imageWrapperSelector}  > img`;
+exports.imageWrapperSelector = imageWrapperSelector;
+exports.imageSelector = imageSelector;
+exports.imageBackgroundSelector = imageBackgroundSelector;

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -22,7 +22,7 @@ exports.onRouteUpdate = () => {
       imageElement.removeEventListener(`load`, onImageLoad);
     };
 
-    if (imageElement) {
+    if (imageElement && backgroundElement) {
       if (imageElement.complete) {
         backgroundElement.style.opacity = 0;
       } else {

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,34 @@
+const {
+  imageSelector,
+  imageBackgroundSelector,
+  imageWrapperSelector
+} = require(`./constants`);
+
+exports.onRouteUpdate = () => {
+  const imageWrappers = document.querySelectorAll(imageWrapperSelector); // https://css-tricks.com/snippets/javascript/loop-queryselectorall-matches/
+  // for cross-browser looping through NodeList without polyfills
+
+  for (let i = 0; i < imageWrappers.length; i++) {
+    const imageWrapper = imageWrappers[i];
+    const backgroundElement = imageWrapper.querySelector(imageBackgroundSelector);
+    const imageElement = imageWrapper.querySelector(imageSelector);
+    console.log(imageElement);
+
+    const onImageLoad = () => {
+      backgroundElement.style.transition = `opacity 0.5s 0.5s`;
+      backgroundElement.style.opacity = 0;
+      imageElement.style.transition = `opacity 0.5s`;
+      imageElement.style.opacity = 1;
+      imageElement.removeEventListener(`load`, onImageLoad);
+    };
+
+    if (imageElement) {
+      if (imageElement.complete) {
+        backgroundElement.style.opacity = 0;
+      } else {
+        imageElement.style.opacity = 0;
+        imageElement.addEventListener(`load`, onImageLoad);
+      }
+    }
+  }
+};

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -12,7 +12,6 @@ exports.onRouteUpdate = () => {
     const imageWrapper = imageWrappers[i];
     const backgroundElement = imageWrapper.querySelector(imageBackgroundSelector);
     const imageElement = imageWrapper.querySelector(imageSelector);
-    console.log(imageElement);
 
     const onImageLoad = () => {
       backgroundElement.style.transition = `opacity 0.5s 0.5s`;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -20,7 +20,11 @@ exports.sourceNodes = async (
   const defaults = {
     maxWidth: 650,
     wrapperStyle: ``,
-    backgroundColor: `white`
+    backgroundColor: `white`,
+    postTypes: [
+      'post',
+      'page'
+    ]
     // linkImagesToOriginal: true,
     // showCaptions: false,
     // pathPrefix,
@@ -36,7 +40,7 @@ exports.sourceNodes = async (
   const entities = nodes.filter(
     node =>
       node.internal.owner === "gatsby-source-wordpress" &&
-      ["post", "page"].includes(node.type)
+      options.postTypes.includes(node.type)
   );
 
   // we need to await transforming all the entities since we may need to get images remotely and generating fluid image data is async

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,101 +1,90 @@
-const _ = require("lodash");
-const cheerio = require(`cheerio`);
-const { createRemoteFileNode } = require(`gatsby-source-filesystem`);
-const { fluid } = require(`gatsby-plugin-sharp`);
+const _ = require(`lodash`);
 
-const removeImageSizes = require("./utils/removeImageSizes");
+const React = require(`react`);
+
+const ReactDOMServer = require(`react-dom/server`);
+
+const cheerio = require(`cheerio`);
 
 const {
-  imageClass,
-  imageBackgroundClass,
-  imageWrapperClass
-} = require(`./constants`);
+  createRemoteFileNode
+} = require(`gatsby-source-filesystem`);
 
-exports.sourceNodes = async (
-  { getNodes, cache, reporter, store, actions, createNodeId },
-  pluginOptions
-) => {
-  const { createNode } = actions;
+const {
+  fluid
+} = require(`gatsby-plugin-sharp`);
 
+const Img = require(`gatsby-image`);
+
+const parseWPImagePath = require(`./utils/parseWPImagePath`);
+
+exports.sourceNodes = async ({
+  getNodes,
+  cache,
+  reporter,
+  store,
+  actions,
+  createNodeId
+}, pluginOptions) => {
+  const {
+    createNode
+  } = actions;
   const defaults = {
     maxWidth: 650,
     wrapperStyle: ``,
     backgroundColor: `white`,
-    postTypes: [
-      'post',
-      'page'
-    ]
-    // linkImagesToOriginal: true,
+    postTypes: ["post", "page"],
+    withWebp: false // linkImagesToOriginal: true,
     // showCaptions: false,
     // pathPrefix,
     // withWebp: false
+
   };
 
   const options = _.defaults(pluginOptions, defaults);
 
-  const nodes = getNodes();
-
-  // for now just get all posts and pages.
+  const nodes = getNodes(); // for now just get all posts and pages.
   // this will be dynamic later
-  const entities = nodes.filter(
-    node =>
-      node.internal.owner === "gatsby-source-wordpress" &&
-      options.postTypes.includes(node.type)
-  );
 
-  // we need to await transforming all the entities since we may need to get images remotely and generating fluid image data is async
-  await Promise.all(
-    entities.map(async entity =>
-      transformInlineImagestoStaticImages(
-        {
-          entity,
-          cache,
-          reporter,
-          store,
-          createNode,
-          createNodeId
-        },
-        options
-      )
-    )
-  );
+  const entities = nodes.filter(node => node.internal.owner === "gatsby-source-wordpress" && options.postTypes.includes(node.type)); // we need to await transforming all the entities since we may need to get images remotely and generating fluid image data is async
+
+  await Promise.all(entities.map(async entity => transformInlineImagestoStaticImages({
+    entity,
+    cache,
+    reporter,
+    store,
+    createNode,
+    createNodeId
+  }, options)));
 };
 
-const transformInlineImagestoStaticImages = async (
-  { entity, cache, reporter, store, createNode, createNodeId },
-  options
-) => {
+const transformInlineImagestoStaticImages = async ({
+  entity,
+  cache,
+  reporter,
+  store,
+  createNode,
+  createNodeId
+}, options) => {
   const field = entity.content;
-
-  if ((!field && typeof field !== "string") || !field.includes("<img")) return;
-
+  if (!field && typeof field !== "string" || !field.includes("<img")) return;
   const $ = cheerio.load(field);
-
   const imgs = $(`img`);
-
   if (imgs.length === 0) return;
-
   let imageRefs = [];
-
-  imgs.each(function() {
+  imgs.each(function () {
     imageRefs.push($(this));
   });
-
-  await Promise.all(
-    imageRefs.map(thisImg =>
-      replaceImage({
-        thisImg,
-        options,
-        cache,
-        reporter,
-        $,
-        store,
-        createNode,
-        createNodeId
-      })
-    )
-  );
-
+  await Promise.all(imageRefs.map(thisImg => replaceImage({
+    thisImg,
+    options,
+    cache,
+    reporter,
+    $,
+    store,
+    createNode,
+    createNodeId
+  })));
   entity.content = $.html();
 };
 
@@ -110,8 +99,8 @@ const replaceImage = async ({
   $
 }) => {
   // find the full size image that matches, throw away WP resizes
-  const url = removeImageSizes(thisImg.attr("src"));
-
+  const parsedUrlData = parseWPImagePath(thisImg.attr("src"));
+  const url = parsedUrlData.cleanUrl;
   const imageNode = await downloadMediaFile({
     url,
     cache,
@@ -119,22 +108,19 @@ const replaceImage = async ({
     createNode,
     createNodeId
   });
-
   if (!imageNode) return;
-
   let classes = thisImg.attr("class");
   let formattedImgTag = {};
   formattedImgTag.url = thisImg.attr(`src`);
   formattedImgTag.classList = classes ? classes.split(" ") : [];
   formattedImgTag.title = thisImg.attr(`title`);
   formattedImgTag.alt = thisImg.attr(`alt`);
-
+  if (parsedUrlData.width) formattedImgTag.width = parsedUrlData.width;
+  if (parsedUrlData.height) formattedImgTag.height = parsedUrlData.height;
   if (!formattedImgTag.url) return;
-
-  const fileType = imageNode.ext;
-
-  // Ignore gifs as we can't process them,
+  const fileType = imageNode.ext; // Ignore gifs as we can't process them,
   // svgs as they are already responsive by definition
+
   if (fileType !== `gif` && fileType !== `svg`) {
     const rawHTML = await generateImagesAndUpdateNode({
       formattedImgTag,
@@ -143,16 +129,15 @@ const replaceImage = async ({
       cache,
       reporter,
       $
-    });
+    }); // Replace the image string
 
-    // Replace the image string
     if (rawHTML) thisImg.replaceWith(rawHTML);
   }
-};
-
-// Takes a node and generates the needed images and then returns
+}; // Takes a node and generates the needed images and then returns
 // the needed HTML replacement for the image
-const generateImagesAndUpdateNode = async function({
+
+
+const generateImagesAndUpdateNode = async function ({
   formattedImgTag,
   imageNode,
   options,
@@ -161,152 +146,48 @@ const generateImagesAndUpdateNode = async function({
   $
 }) {
   if (!imageNode || !imageNode.absolutePath) return;
-
+  let fluidResultWebp;
   let fluidResult = await fluid({
     file: imageNode,
-    args: options,
+    args: { ...options,
+      maxWidth: formattedImgTag.width || options.maxWidth
+    },
     reporter,
     cache
   });
 
+  if (options.withWebp) {
+    fluidResultWebp = await fluid({
+      file: imageNode,
+      args: { ...options,
+        maxWidth: formattedImgTag.width || options.maxWidth,
+        toFormat: 'WEBP'
+      },
+      reporter,
+      cache
+    });
+  }
+
   if (!fluidResult) return;
 
-  const fallbackSrc = fluidResult.src;
-  const srcSet = fluidResult.srcSet;
-  const presentationWidth = fluidResult.presentationWidth;
-  const fullsizeImgLink = fluidResult.originalImg;
+  if (options.withWebp) {
+    fluidResult.srcSetWebp = fluidResultWebp.srcSet;
+  }
 
-  // replace WP image links
-  $(`a`).each(function() {
-    if (
-      removeImageSizes($(this).attr("href")) ===
-      removeImageSizes(formattedImgTag.url)
-    ) {
-      $(this).attr("href", fullsizeImgLink);
+  const imgOptions = {
+    fluid: fluidResult,
+    style: {},
+    // Force show full image instantly
+    critical: true,
+    // fadeIn: true,
+    imgStyle: {
+      opacity: 1
     }
-  });
-
-  // Generate default alt tag
-  const srcSplit = fluidResult.src.split(`/`);
-  const fileName = srcSplit[srcSplit.length - 1];
-  const fileNameNoExt = fileName.replace(/\.[^/.]+$/, ``);
-  const defaultAlt = fileNameNoExt.replace(/[^A-Z0-9]/gi, ` `);
-
-  const imageStyle = `
-      width: 100%;
-      height: 100%;
-      margin: 0;
-      vertical-align: middle;
-      position: absolute;
-      top: 0;
-      left: 0;
-      box-shadow: inset 0px 0px 0px 400px ${options.backgroundColor};`.replace(
-    /\s*(\S+:)\s*/g,
-    `$1`
-  );
-
-  // Create our base image tag
-  let imageTag = `
-      <img
-        class="${imageClass} ${formattedImgTag.classList.join(" ")}"
-        style="${imageStyle}"
-        alt="${formattedImgTag.alt ? formattedImgTag.alt : defaultAlt}"
-        title="${formattedImgTag.title ? formattedImgTag.title : ``}"
-        src="${fallbackSrc}"
-        srcset="${srcSet}"
-        sizes="${fluidResult.sizes}"
-      />
-    `.trim();
-
-  // // if options.withWebp is enabled, generate a webp version and change the image tag to a picture tag
-  // if (options.withWebp) {
-  //   const webpFluidResult = await fluid({
-  //     file: imageNode,
-  //     args: _.defaults(
-  //       { toFormat: `WEBP` },
-  //       // override options if it's an object, otherwise just pass through defaults
-  //       options.withWebp === true ? {} : options.withWebp,
-  //       pluginOptions,
-  //       defaults
-  //     ),
-  //     reporter,
-  //   })
-
-  //   if (!webpFluidResult) {
-  //     return false;
-  //   }
-
-  //   imageTag = `
-  //   <picture>
-  //     <source
-  //       srcset="${webpFluidResult.srcSet}"
-  //       sizes="${webpFluidResult.sizes}"
-  //       type="${webpFluidResult.srcSetType}"
-  //     />
-  //     <source
-  //       srcset="${srcSet}"
-  //       sizes="${fluidResult.sizes}"
-  //       type="${fluidResult.srcSetType}"
-  //     />
-  //     <img
-  //       class="${imageClass}"
-  //       style="${imageStyle}"
-  //       src="${fallbackSrc}"
-  //       alt="${node.alt ? node.alt : defaultAlt}"
-  //       title="${node.title ? node.title : ``}"
-  //     />
-  //   </picture>
-  //   `.trim()
-  // }
-
-  const ratio = `${(1 / fluidResult.aspectRatio) * 100}%`;
-
-  // Construct new image node w/ aspect ratio placeholder
-  // const showCaptions = options.showCaptions && node.title
-  const showCaptions = false;
-
-  let rawHTML = `
-  <span
-    class="${imageWrapperClass}"
-    style="position: relative; display: block; ${
-      showCaptions ? `` : options.wrapperStyle
-    } max-width: ${presentationWidth}px; margin-left: auto; margin-right: auto;"
-  >
-    <span
-      class="${imageBackgroundClass}"
-      style="padding-bottom: ${ratio}; position: relative; bottom: 0; left: 0; background-image: url('${
-    fluidResult.base64
-  }'); background-size: cover; display: block;"
-    ></span>
-    ${imageTag}
-  </span>
-  `.trim();
-
-  //   // Make linking to original image optional.
-  //   if (!inLink && options.linkImagesToOriginal) {
-  //     rawHTML = `
-  // <a
-  //   class="gatsby-resp-image-link"
-  //   href="${originalImg}"
-  //   style="display: block"
-  //   target="_blank"
-  //   rel="noopener"
-  // >
-  //   ${rawHTML}
-  // </a>
-  //   `.trim()
-  //   }
-
-  //   // Wrap in figure and use title as caption
-  //   if (showCaptions) {
-  //     rawHTML = `
-  // <figure class="gatsby-resp-image-figure" style="${options.wrapperStyle}">
-  //   ${rawHTML}
-  //   <figcaption class="gatsby-resp-image-figcaption">${node.title}</figcaption>
-  // </figure>
-  //     `.trim()
-  //   }
-  return rawHTML;
+  };
+  if (formattedImgTag.width) imgOptions.style.width = formattedImgTag.width;
+  if (formattedImgTag.height) imgOptions.style.height = formattedImgTag.height;
+  const ReactImgEl = React.createElement(Img.default, imgOptions, null);
+  return ReactDOMServer.renderToString(ReactImgEl);
 };
 
 const downloadMediaFile = async ({
@@ -324,10 +205,10 @@ const downloadMediaFile = async ({
   //   fileNodeID = cacheMediaData.fileNodeID
   //   touchNode({ nodeId: cacheMediaData.fileNodeID })
   // }
-
   // If we don't have cached data, download the file
   // if (!fileNodeID) {
   let fileNode = false;
+
   try {
     fileNode = await createRemoteFileNode({
       url,
@@ -335,8 +216,7 @@ const downloadMediaFile = async ({
       cache,
       createNode,
       createNodeId
-    });
-    // auth: _auth,
+    }); // auth: _auth,
     // if (fileNode) {
     //   fileNodeID = fileNode.id
     //   // await cache.set(mediaDataCacheKey, {
@@ -344,16 +224,13 @@ const downloadMediaFile = async ({
     //   //   modified: e.modified,
     //   // })
     // }
-  } catch (e) {
-    // Ignore
-  }
+  } catch (e) {} // Ignore
   // }
 
-  return fileNode;
-  // if (fileNodeID) {
+
+  return fileNode; // if (fileNodeID) {
   //   e.localFile___NODE = fileNodeID
   //   delete e.media_details.sizes
   // }
-
   // return e
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -176,7 +176,9 @@ const generateImagesAndUpdateNode = async function ({
 
   const imgOptions = {
     fluid: fluidResult,
-    style: {},
+    style: {
+      maxWidth: "100%"
+    },
     // Force show full image instantly
     critical: true,
     // fadeIn: true,
@@ -185,7 +187,6 @@ const generateImagesAndUpdateNode = async function ({
     }
   };
   if (formattedImgTag.width) imgOptions.style.width = formattedImgTag.width;
-  if (formattedImgTag.height) imgOptions.style.height = formattedImgTag.height;
   const ReactImgEl = React.createElement(Img.default, imgOptions, null);
   return ReactDOMServer.renderToString(ReactImgEl);
 };

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-// nnooops??
+// no-op-lo-op

--- a/package.json
+++ b/package.json
@@ -9,6 +9,18 @@
   "license": "MIT",
   "main": "n/a",
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "cheerio": "^1.0.0-rc.2"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.0.0",
+    "@babel/core": "^7.0.0",
+    "babel-preset-gatsby-package": "^0.1.4",
+    "cross-env": "^5.1.4"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore **/__tests__",
+    "prepare": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w ./src --out-dir . --extensions '.js' --ignore **/__tests__"
   }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,7 @@
+const imageWrapperSelector = `.gatsby-image-wrapper`
+const imageSelector = `${imageWrapperSelector} picture img`
+const imageBackgroundSelector = `${imageWrapperSelector}  > img`
+
+exports.imageWrapperSelector = imageWrapperSelector
+exports.imageSelector = imageSelector
+exports.imageBackgroundSelector = imageBackgroundSelector

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -15,8 +15,6 @@ exports.onRouteUpdate = () => {
     const backgroundElement = imageWrapper.querySelector(imageBackgroundSelector)
     const imageElement = imageWrapper.querySelector(imageSelector)
 
-    console.log(imageElement)
-
     const onImageLoad = () => {
       backgroundElement.style.transition = `opacity 0.5s 0.5s`
       backgroundElement.style.opacity = 0

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,0 +1,37 @@
+const {
+  imageSelector,
+  imageBackgroundSelector,
+  imageWrapperSelector,
+} = require(`./constants`)
+
+exports.onRouteUpdate = () => {
+  const imageWrappers = document.querySelectorAll(imageWrapperSelector)
+
+  // https://css-tricks.com/snippets/javascript/loop-queryselectorall-matches/
+  // for cross-browser looping through NodeList without polyfills
+  for (let i = 0; i < imageWrappers.length; i++) {
+    const imageWrapper = imageWrappers[i]
+
+    const backgroundElement = imageWrapper.querySelector(imageBackgroundSelector)
+    const imageElement = imageWrapper.querySelector(imageSelector)
+
+    console.log(imageElement)
+
+    const onImageLoad = () => {
+      backgroundElement.style.transition = `opacity 0.5s 0.5s`
+      backgroundElement.style.opacity = 0
+      imageElement.style.transition = `opacity 0.5s`
+      imageElement.style.opacity = 1
+      imageElement.removeEventListener(`load`, onImageLoad)
+    }
+
+    if (imageElement) {
+      if (imageElement.complete) {
+        backgroundElement.style.opacity = 0
+      } else {
+        imageElement.style.opacity = 0
+        imageElement.addEventListener(`load`, onImageLoad)
+      }
+    }
+  }
+}

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -25,7 +25,7 @@ exports.onRouteUpdate = () => {
       imageElement.removeEventListener(`load`, onImageLoad)
     }
 
-    if (imageElement) {
+    if (imageElement && backgroundElement) {
       if (imageElement.complete) {
         backgroundElement.style.opacity = 0
       } else {

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,0 +1,258 @@
+const _ = require(`lodash`)
+const React = require(`react`)
+const ReactDOMServer = require(`react-dom/server`)
+const cheerio = require(`cheerio`)
+const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
+const { fluid } = require(`gatsby-plugin-sharp`)
+const Img = require(`gatsby-image`)
+
+const parseWPImagePath = require(`./utils/parseWPImagePath`)
+
+exports.sourceNodes = async (
+  { getNodes, cache, reporter, store, actions, createNodeId },
+  pluginOptions
+) => {
+  const { createNode } = actions
+
+  const defaults = {
+    maxWidth: 650,
+    wrapperStyle: ``,
+    backgroundColor: `white`,
+    postTypes: ["post", "page"],
+    withWebp: false
+    // linkImagesToOriginal: true,
+    // showCaptions: false,
+    // pathPrefix,
+    // withWebp: false
+  }
+
+  const options = _.defaults(pluginOptions, defaults)
+
+  const nodes = getNodes()
+
+  // for now just get all posts and pages.
+  // this will be dynamic later
+  const entities = nodes.filter(
+    node =>
+      node.internal.owner === "gatsby-source-wordpress" &&
+      options.postTypes.includes(node.type)
+  )
+
+  // we need to await transforming all the entities since we may need to get images remotely and generating fluid image data is async
+  await Promise.all(
+    entities.map(async entity =>
+      transformInlineImagestoStaticImages(
+        {
+          entity,
+          cache,
+          reporter,
+          store,
+          createNode,
+          createNodeId,
+        },
+        options
+      )
+    )
+  )
+}
+
+const transformInlineImagestoStaticImages = async (
+  { entity, cache, reporter, store, createNode, createNodeId },
+  options
+) => {
+  const field = entity.content
+
+  if ((!field && typeof field !== "string") || !field.includes("<img")) return
+
+  const $ = cheerio.load(field)
+
+  const imgs = $(`img`)
+
+  if (imgs.length === 0) return
+
+  let imageRefs = []
+
+  imgs.each(function() {
+    imageRefs.push($(this))
+  })
+
+  await Promise.all(
+    imageRefs.map(thisImg =>
+      replaceImage({
+        thisImg,
+        options,
+        cache,
+        reporter,
+        $,
+        store,
+        createNode,
+        createNodeId,
+      })
+    )
+  )
+
+  entity.content = $.html()
+}
+
+const replaceImage = async ({
+  thisImg,
+  options,
+  cache,
+  store,
+  createNode,
+  createNodeId,
+  reporter,
+  $,
+}) => {
+  // find the full size image that matches, throw away WP resizes
+  const parsedUrlData = parseWPImagePath(thisImg.attr("src"))
+  const url = parsedUrlData.cleanUrl
+
+  const imageNode = await downloadMediaFile({
+    url,
+    cache,
+    store,
+    createNode,
+    createNodeId,
+  })
+
+  if (!imageNode) return
+
+  let classes = thisImg.attr("class")
+  let formattedImgTag = {}
+  formattedImgTag.url = thisImg.attr(`src`)
+  formattedImgTag.classList = classes ? classes.split(" ") : []
+  formattedImgTag.title = thisImg.attr(`title`)
+  formattedImgTag.alt = thisImg.attr(`alt`)
+
+  if (parsedUrlData.width) formattedImgTag.width = parsedUrlData.width
+  if (parsedUrlData.height) formattedImgTag.height = parsedUrlData.height
+
+  if (!formattedImgTag.url) return
+
+  const fileType = imageNode.ext
+
+  // Ignore gifs as we can't process them,
+  // svgs as they are already responsive by definition
+  if (fileType !== `gif` && fileType !== `svg`) {
+    const rawHTML = await generateImagesAndUpdateNode({
+      formattedImgTag,
+      imageNode,
+      options,
+      cache,
+      reporter,
+      $,
+    })
+
+    // Replace the image string
+    if (rawHTML) thisImg.replaceWith(rawHTML)
+  }
+}
+
+// Takes a node and generates the needed images and then returns
+// the needed HTML replacement for the image
+const generateImagesAndUpdateNode = async function({
+  formattedImgTag,
+  imageNode,
+  options,
+  cache,
+  reporter,
+  $,
+}) {
+  if (!imageNode || !imageNode.absolutePath) return
+
+  let fluidResultWebp
+  let fluidResult = await fluid({
+    file: imageNode,
+    args: {
+      ...options,
+      maxWidth: formattedImgTag.width || options.maxWidth,
+    },
+    reporter,
+    cache,
+  })
+
+  if (options.withWebp) {
+    fluidResultWebp = await fluid({
+      file: imageNode,
+      args: {
+        ...options,
+        maxWidth: formattedImgTag.width || options.maxWidth,
+        toFormat: 'WEBP'
+      },
+      reporter,
+      cache,
+    })
+  }
+
+  if (!fluidResult) return
+
+  if (options.withWebp) {
+    fluidResult.srcSetWebp = fluidResultWebp.srcSet
+  }
+
+  const imgOptions = {
+    fluid: fluidResult,
+    style: {},
+    // Force show full image instantly
+    critical: true,
+    // fadeIn: true,
+    imgStyle: {
+      opacity: 1
+    }
+  }
+  if (formattedImgTag.width) imgOptions.style.width = formattedImgTag.width
+  if (formattedImgTag.height) imgOptions.style.height = formattedImgTag.height
+
+  const ReactImgEl = React.createElement(Img.default, imgOptions, null)
+  return ReactDOMServer.renderToString(ReactImgEl)
+}
+
+const downloadMediaFile = async ({
+  url,
+  cache,
+  store,
+  createNode,
+  createNodeId,
+}) => {
+  // const mediaDataCacheKey = `wordpress-media-${e.wordpress_id}`
+  // const cacheMediaData = await cache.get(mediaDataCacheKey)
+  // // If we have cached media data and it wasn't modified, reuse
+  // // previously created file node to not try to redownload
+  // if (cacheMediaData && e.modified === cacheMediaData.modified) {
+  //   fileNodeID = cacheMediaData.fileNodeID
+  //   touchNode({ nodeId: cacheMediaData.fileNodeID })
+  // }
+
+  // If we don't have cached data, download the file
+  // if (!fileNodeID) {
+  let fileNode = false
+  try {
+    fileNode = await createRemoteFileNode({
+      url,
+      store,
+      cache,
+      createNode,
+      createNodeId,
+    })
+    // auth: _auth,
+    // if (fileNode) {
+    //   fileNodeID = fileNode.id
+    //   // await cache.set(mediaDataCacheKey, {
+    //   //   fileNodeID,
+    //   //   modified: e.modified,
+    //   // })
+    // }
+  } catch (e) {
+    // Ignore
+  }
+  // }
+
+  return fileNode
+  // if (fileNodeID) {
+  //   e.localFile___NODE = fileNodeID
+  //   delete e.media_details.sizes
+  // }
+
+  // return e
+}

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -193,7 +193,9 @@ const generateImagesAndUpdateNode = async function({
 
   const imgOptions = {
     fluid: fluidResult,
-    style: {},
+    style: {
+      maxWidth: "100%"
+    },
     // Force show full image instantly
     critical: true,
     // fadeIn: true,
@@ -202,7 +204,6 @@ const generateImagesAndUpdateNode = async function({
     }
   }
   if (formattedImgTag.width) imgOptions.style.width = formattedImgTag.width
-  if (formattedImgTag.height) imgOptions.style.height = formattedImgTag.height
 
   const ReactImgEl = React.createElement(Img.default, imgOptions, null)
   return ReactDOMServer.renderToString(ReactImgEl)

--- a/src/utils/parseWPImagePath.js
+++ b/src/utils/parseWPImagePath.js
@@ -1,0 +1,17 @@
+// this function removes wordpress iamge sizes from a string
+module.exports = function parseWPImagePath(urlpath) {
+  const imageSizesPattern = new RegExp("(?:[-_]([0-9]+)x([0-9]+))")
+  const sizesMatch = urlpath.match(imageSizesPattern)
+  const urlpath_remove_sizes = urlpath.replace(imageSizesPattern, "")
+
+  const result = {
+    cleanUrl: urlpath_remove_sizes
+  }
+
+  if (sizesMatch) {
+    result.width = Number(sizesMatch[1]),
+    result.height = Number(sizesMatch[2])
+  }
+
+  return result
+}

--- a/utils/parseWPImagePath.js
+++ b/utils/parseWPImagePath.js
@@ -1,0 +1,15 @@
+// this function removes wordpress iamge sizes from a string
+module.exports = function parseWPImagePath(urlpath) {
+  const imageSizesPattern = new RegExp("(?:[-_]([0-9]+)x([0-9]+))");
+  const sizesMatch = urlpath.match(imageSizesPattern);
+  const urlpath_remove_sizes = urlpath.replace(imageSizesPattern, "");
+  const result = {
+    cleanUrl: urlpath_remove_sizes
+  };
+
+  if (sizesMatch) {
+    result.width = Number(sizesMatch[1]), result.height = Number(sizesMatch[2]);
+  }
+
+  return result;
+};

--- a/utils/removeImageSizes.js
+++ b/utils/removeImageSizes.js
@@ -1,9 +1,0 @@
-// this function removes wordpress iamge sizes from a string
-function removeImageSizes(urlpath) {
-  const imageSizesPattern = new RegExp("(?:[-_][0-9]+x[0-9]+)");
-  const urlpath_remove_sizes = urlpath.replace(imageSizesPattern, "");
-
-  return urlpath_remove_sizes;
-}
-
-module.exports = removeImageSizes;


### PR DESCRIPTION
Add `gatsby-image` as image creator engine
Add transpiler script to ES5
Add default blur-up effect for created images
Add WebP support
Now sharp respect image size when transform it
Add support for content images (floated)
Manual creation of image replaced with `gatsby-image` rendered component

I think now we can remove ALPHA tag from plugin name