### PR TITLE
Feat: Include ACF

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Be sure to specify your baseurl and protocol a second time in the `gatsby-wordpr
 		postTypes: ["post", "page"],
 		backgroundColor: `white`,
 		withWebp: false, // enable WebP files generation
+		includeACF: false, // process <img> tags in ACF fields too
 		// add any image sharp fluid options here
 		// ...
 	}


### PR DESCRIPTION
This plugin only parses the "content" field of Wordpress nodes, but ignores ACF fields that can contain images too.
This pull request adds support for parsing ACFs and includes a plugin option "includeACF" (false by default) to turn on this feature.