### PR TITLE
Fix empty img

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -73,7 +73,9 @@ const transformInlineImagestoStaticImages = async ({
   if (imgs.length === 0) return;
   let imageRefs = [];
   imgs.each(function () {
-    imageRefs.push($(this));
+    let img = $(this)
+    if (img.attr("src"))
+      imageRefs.push(img)
   });
   await Promise.all(imageRefs.map(thisImg => replaceImage({
     thisImg,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -67,7 +67,7 @@ const transformInlineImagestoStaticImages = async ({
   createNodeId
 }, options) => {
   const field = entity.content;
-  if (!field && typeof field !== "string" || !field.includes("<img")) return;
+  if (typeof field !== "string" || !field.includes("<img")) return;
   const $ = cheerio.load(field);
   const imgs = $(`img`);
   if (imgs.length === 0) return;


### PR DESCRIPTION
This pull request fixes 2 bugs:
* Ignores `<img src="">` tags that caused `TypeError: Cannot read property replace of undefined` (maybe related to #2)
* Fixes an if condition that fails when trying to process null fields (needed for #6)