### PR TITLE
fix: original image with size

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -107,14 +107,31 @@ const replaceImage = async ({
   // find the full size image that matches, throw away WP resizes
   const parsedUrlData = parseWPImagePath(thisImg.attr("src"))
   const url = parsedUrlData.cleanUrl
+  let imageNode;
 
-  const imageNode = await downloadMediaFile({
-    url,
-    cache,
-    store,
-    createNode,
-    createNodeId,
-  })
+  try{
+    imageNode = await downloadMediaFile({
+      url,
+      cache,
+      store,
+      createNode,
+      createNodeId,
+    })
+  }
+  catch(e) {
+   try {
+    imageNode = await downloadMediaFile({
+      parsedUrlData,
+      cache,
+      store,
+      createNode,
+      createNodeId,
+    })
+   }
+   catch(e) {
+     // Do nothing
+   }
+  }
 
   if (!imageNode) return
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -109,6 +109,7 @@ const replaceImage = async ({
   const url = parsedUrlData.cleanUrl
   let imageNode;
 
+  // Try to download the full size image without the WP resize parameters (removed on parse)
   try{
     imageNode = await downloadMediaFile({
       url,
@@ -119,6 +120,8 @@ const replaceImage = async ({
     })
   }
   catch(e) {
+    // If the image without WP resize parameters on the URL does not exist it means that the original file has sizes
+    // Try to download the image with the original URL
    try {
     imageNode = await downloadMediaFile({
       parsedUrlData,


### PR DESCRIPTION
@riencoertjens this fixes the issue discussed here https://github.com/TylerBarnes/gatsby-wordpress-inline-images/issues/15.

Please let me know if you have any question.