### PR TITLE
Fix/get original url

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -169,7 +169,7 @@ const replaceImage = async ({
 		// Try to download the image with the original URL
 		try {
 			imageNode = await downloadMediaFile({
-				url: originalUrl, //<- important use `url`
+				url: originalUrl,
 				cache,
 				store,
 				createNode,

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -152,7 +152,7 @@ const replaceImage = async ({
 	// find the full size image that matches, throw away WP resizes
 	const parsedUrlData = parseWPImagePath(thisImg.attr("src"))
 	const url = parsedUrlData.cleanUrl
-
+	const { originalUrl } = parsedUrlData;
 	let imageNode
 
 	// Try to download the full size image without the WP resize parameters (removed on parse)
@@ -169,7 +169,7 @@ const replaceImage = async ({
 		// Try to download the image with the original URL
 		try {
 			imageNode = await downloadMediaFile({
-				parsedUrlData,
+				url: originalUrl, //<- important use `url`
 				cache,
 				store,
 				createNode,
@@ -311,7 +311,7 @@ const downloadMediaFile = async ({
 		//   // })
 		// }
 	} catch (e) {
-		// Ignore
+		throw Error(e);
 	}
 	// }
 

--- a/src/utils/parseWPImagePath.js
+++ b/src/utils/parseWPImagePath.js
@@ -5,7 +5,8 @@ module.exports = function parseWPImagePath(urlpath) {
   const urlpath_remove_sizes = urlpath.replace(imageSizesPattern, "")
 
   const result = {
-    cleanUrl: urlpath_remove_sizes
+    cleanUrl: urlpath_remove_sizes,
+    originalUrl: urlpath
   }
 
   if (sizesMatch) {


### PR DESCRIPTION
This PR is for solve a problem in function `downloadMediaFile`, because  return a boolean instep of an Error, then when the image without WP resize parameters on the URL does not exist return a false and the catch block never execute.